### PR TITLE
Security time fix

### DIFF
--- a/website_rentals/controllers/website_rental_controller.py
+++ b/website_rentals/controllers/website_rental_controller.py
@@ -28,7 +28,7 @@ class WebsiteRentalController(Controller):
             .sudo()\
             .search_read(
                 [("id", "=", product_id)],
-                fields=("id", "name", "display_name", "description_sale"),
+                fields=("id", "name", "display_name", "description_sale", "preparation_time"),
                 limit=1,
             )
 

--- a/website_rentals/helpers/__init__.py
+++ b/website_rentals/helpers/__init__.py
@@ -1,1 +1,2 @@
 from . import scheduling
+from . import time

--- a/website_rentals/helpers/scheduling.py
+++ b/website_rentals/helpers/scheduling.py
@@ -61,7 +61,7 @@ class SchedulingHelper(models.AbstractModel):
             if self.range_overlaps(
                 (start_date, stop_date),
                 (
-                    reservation.pickup_date - timedelta(hours=-reservation.product_id.product_tmpl_id.preparation_time),
+                    reservation.pickup_date,
                     reservation.return_date
                 ),
             ):

--- a/website_rentals/helpers/time.py
+++ b/website_rentals/helpers/time.py
@@ -1,0 +1,6 @@
+import dateutil
+
+def parse_datetime(data):
+    if type(data) != str:
+        return data.replace(tzinfo=None)
+    return dateutil.parser.parse(data).replace(tzinfo=None)

--- a/website_rentals/models/product.py
+++ b/website_rentals/models/product.py
@@ -1,6 +1,7 @@
 import datetime
 import dateutil
 from odoo import _, models
+from odoo.addons.website_rentals.helpers.time import parse_datetime
 
 
 class Product(models.Model):
@@ -27,7 +28,7 @@ class Product(models.Model):
         """
 
         now = datetime.datetime.now()
-        date = dateutil.parser.parse(date).replace(tzinfo=None)
+        date = parse_datetime(date)
 
         if not self.rental_pricing_ids:
             return

--- a/website_rentals/static/src/components/RentalWizard.js
+++ b/website_rentals/static/src/components/RentalWizard.js
@@ -1,8 +1,9 @@
 odoo.define("website_rentals.RentalWizard", function (require) {
     const { Component } = owl;
-    const { useState, useRef, useEffect } = owl.hooks;
+    const { useState, useRef } = owl.hooks;
     const { xml, css } = owl.tags;
     const DateRangePicker = require("website_rentals.DateRangePicker");
+    const useCurrentTime = require("website_rentals.hooks.useCurrentTime");
     const wUtils = require("website.utils");
 
     const TEMPLATE = xml `
@@ -40,7 +41,7 @@ odoo.define("website_rentals.RentalWizard", function (require) {
                                                 type="date"
                                                 autocomplete="off"
                                                 required="1"
-                                                t-att-min="today()"
+                                                t-att-min="time.now.add(state.product.preparation_time || 0, 'hours').format('YYYY-MM-DD')"
                                                 t-att-disabled="state.loading"/>
                                             <span style="padding:0 8px;">to</span>
                                             <input
@@ -51,7 +52,7 @@ odoo.define("website_rentals.RentalWizard", function (require) {
                                                 type="date"
                                                 autocomplete="off"
                                                 required="1"
-                                                t-att-min="state.startDateInput || today()"
+                                                t-att-min="state.startDateInput || time.now.format('YYYY-MM-DD')"
                                                 t-att-disabled="!state.startDateInput || state.loading"/>
                                         </div>
                                     </div>
@@ -183,6 +184,8 @@ odoo.define("website_rentals.RentalWizard", function (require) {
         refs = {
             pickupReturnPicker: useRef("pickup-return-picker")
         };
+
+        time = useCurrentTime();
 
         constructor(parent, props) {
             super(parent, props)
@@ -482,10 +485,6 @@ odoo.define("website_rentals.RentalWizard", function (require) {
 
         endDateFormatted() {
             return this.endDate(true).format("YYYY-MM-DD HH:mm:ss");
-        }
-
-        today() {
-            return moment(new Date()).format("YYYY-MM-DD")
         }
     }
 

--- a/website_rentals/static/src/js/hooks/useCurrentTime.js
+++ b/website_rentals/static/src/js/hooks/useCurrentTime.js
@@ -1,0 +1,30 @@
+odoo.define("website_rentals.hooks.useCurrentTime", function(require) {
+    const { useState, onWillStart, onWillUnmount } = owl.hooks;
+
+    /**
+     * Hook which tracks the current time, updating every 1s.
+     *
+     * Be aware that the date object is stored as a moment() object, not a
+     * native Date object.
+     *
+     * Usage:
+     *     class MyComponent extends Component {
+     *         static TEMPLATE = xml`
+     *             <div>
+     *                 Current Time: <span t-esc="time.now"/>
+     *             </div>
+     *         `;
+     *
+     *         time = useCurrentTime()
+     *     }
+     */
+    return function useCurrentTime() {
+        const state = useState({ now: moment(), timer: undefined });
+        const update = () => state.now = moment();
+
+        onWillStart(() => state.timer = setInterval(update, 1000));
+        onWillUnmount(() => clearInterval(state.timer));
+
+        return state;
+    };
+});

--- a/website_rentals/tests/test_scheduling.py
+++ b/website_rentals/tests/test_scheduling.py
@@ -188,3 +188,6 @@ class SchedulingTests(TransactionCase):
         )
         with self.assertRaises(ValidationError):
             order.action_confirm()
+
+    def test_order_cannot_be_entered_during_security_time(self):
+        pass

--- a/website_rentals/tests/test_scheduling.py
+++ b/website_rentals/tests/test_scheduling.py
@@ -3,9 +3,17 @@ from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
+def current_time():
+    # push our current time up 60 seconds to prevent any conflicts with the
+    # time checking, if a function takes a couple of seconds to run then
+    # our current time will fail checks by the security time functions.
+    return datetime.datetime.now() + datetime.timedelta(minutes=1)
+
+
 class SchedulingTests(TransactionCase):
     def setUp(self):
         super().setUp()
+
 
         # sample product data
         self.meeting_room = self.env["product.product"].create(
@@ -16,6 +24,7 @@ class SchedulingTests(TransactionCase):
                 "uom_id": self.env.ref("uom.product_uom_unit").id,
                 "uom_po_id": self.env.ref("uom.product_uom_unit").id,
                 "rent_ok": True,
+                "preparation_time": 0.0  # hours
             }
         )
         self.oil_change = self.env["product.product"].create(
@@ -26,6 +35,18 @@ class SchedulingTests(TransactionCase):
                 "uom_id": self.env.ref("uom.product_uom_unit").id,
                 "uom_po_id": self.env.ref("uom.product_uom_unit").id,
                 "rent_ok": True,
+                "preparation_time": 0.0  # hours
+            }
+        )
+        self.bicycle = self.env["product.product"].create(
+            {
+                "name": "Bicycle",
+                "categ_id": self.env.ref("sale_renting.cat_renting").id,
+                "type": "product",
+                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "uom_po_id": self.env.ref("uom.product_uom_unit").id,
+                "rent_ok": True,
+                "preparation_time": 48.0,  # hours
             }
         )
 
@@ -37,18 +58,25 @@ class SchedulingTests(TransactionCase):
                 "new_quantity": 1.0,
             }
         ).change_product_qty()
+        self.env["stock.change.product.qty"].create(
+            {
+                "product_id": self.bicycle.id,
+                "product_tmpl_id": self.bicycle.product_tmpl_id.id,
+                "new_quantity": 10.0,
+            }
+        ).change_product_qty()
 
     def test_overlapping_dates(self):
         scheduling = self.env["website.rentals.scheduling"]
 
         assert scheduling.range_overlaps(
             (
-                datetime.datetime.now(),
-                datetime.datetime.now() + datetime.timedelta(hours=5),
+                current_time(),
+                current_time() + datetime.timedelta(hours=5),
             ),
             (
-                datetime.datetime.now() - datetime.timedelta(hours=5),
-                datetime.datetime.now() + datetime.timedelta(hours=1),
+                current_time() - datetime.timedelta(hours=5),
+                current_time() + datetime.timedelta(hours=1),
             ),
         )
 
@@ -57,12 +85,12 @@ class SchedulingTests(TransactionCase):
 
         assert not scheduling.range_overlaps(
             (
-                datetime.datetime.now(),
-                datetime.datetime.now() + datetime.timedelta(hours=5),
+                current_time(),
+                current_time() + datetime.timedelta(hours=5),
             ),
             (
-                datetime.datetime.now() - datetime.timedelta(hours=5),
-                datetime.datetime.now() - datetime.timedelta(hours=1),
+                current_time() - datetime.timedelta(hours=5),
+                current_time() - datetime.timedelta(hours=1),
             ),
         )
 
@@ -71,12 +99,12 @@ class SchedulingTests(TransactionCase):
 
         assert scheduling.range_overlaps(
             (
-                datetime.datetime.now(),
-                datetime.datetime.now() + datetime.timedelta(hours=5),
+                current_time(),
+                current_time() + datetime.timedelta(hours=5),
             ),
             (
-                datetime.datetime.now(),
-                datetime.datetime.now() + datetime.timedelta(hours=5),
+                current_time(),
+                current_time() + datetime.timedelta(hours=5),
             ),
         )
 
@@ -85,14 +113,14 @@ class SchedulingTests(TransactionCase):
 
         assert scheduling.get_available_qty(
             self.meeting_room,
-            datetime.datetime.now(),
-            datetime.datetime.now()
+            current_time(),
+            current_time()
         ) == 1.0
 
         assert scheduling.get_available_qty(
             self.oil_change,
-            datetime.datetime.now(),
-            datetime.datetime.now()
+            current_time(),
+            current_time()
         ) == 0.0
 
     def test_rental_orer_without_conflicts(self):
@@ -108,8 +136,8 @@ class SchedulingTests(TransactionCase):
                             "product_id": self.meeting_room.id,
                             "is_rental": True,
                             "product_uom_qty": 1.0,
-                            "pickup_date": datetime.datetime.now(),
-                            "return_date": datetime.datetime.now(),
+                            "pickup_date": current_time(),
+                            "return_date": current_time(),
                         },
                     ),
                 ]
@@ -134,8 +162,8 @@ class SchedulingTests(TransactionCase):
                             "product_id": self.meeting_room.id,
                             "is_rental": True,
                             "product_uom_qty": 5.0,
-                            "pickup_date": datetime.datetime.now() + datetime.timedelta(days=2),
-                            "return_date": datetime.datetime.now() + datetime.timedelta(days=4),
+                            "pickup_date": current_time() + datetime.timedelta(days=2),
+                            "return_date": current_time() + datetime.timedelta(days=4),
                         },
                     ),
                 ]
@@ -158,8 +186,8 @@ class SchedulingTests(TransactionCase):
                             "product_id": self.meeting_room.id,
                             "is_rental": True,
                             "product_uom_qty": 1.0,
-                            "pickup_date": datetime.datetime.now() + datetime.timedelta(days=10),
-                            "return_date": datetime.datetime.now() + datetime.timedelta(days=20),
+                            "pickup_date": current_time() + datetime.timedelta(days=10),
+                            "return_date": current_time() + datetime.timedelta(days=20),
                         },
                     ),
                 ]
@@ -179,8 +207,8 @@ class SchedulingTests(TransactionCase):
                         {
                             "product_id": self.meeting_room.id,
                             "is_rental": True,
-                            "pickup_date": datetime.datetime.now() + datetime.timedelta(days=5),
-                            "return_date": datetime.datetime.now() + datetime.timedelta(days=15),
+                            "pickup_date": current_time() + datetime.timedelta(days=5),
+                            "return_date": current_time() + datetime.timedelta(days=15),
                         },
                     ),
                 ]
@@ -190,4 +218,13 @@ class SchedulingTests(TransactionCase):
             order.action_confirm()
 
     def test_order_cannot_be_entered_during_security_time(self):
-        pass
+        scheduling = self.env["website.rentals.scheduling"]
+
+        # (now, 10 days fromnow), should fail, cannot rent before the bicycle 48 hours security time
+        assert scheduling.can_rent(self.bicycle, current_time(), current_time() + datetime.timedelta(days=10), qty=1) == False
+
+        # (47 hours from now, 10 days from now), should fail, cannot rent before the bicycle 48 hours security time
+        assert scheduling.can_rent(self.bicycle, current_time() + datetime.timedelta(hours=47), current_time() + datetime.timedelta(days=10), qty=1) == False
+
+        # (5 days from now, 10 days from now), after 48 hours security time so should be fine
+        assert scheduling.can_rent(self.bicycle, current_time() + datetime.timedelta(days=5), current_time() + datetime.timedelta(days=10), qty=1) == True

--- a/website_rentals/views/assets.xml
+++ b/website_rentals/views/assets.xml
@@ -4,6 +4,7 @@
         <xpath expr="script[last()]" position="after">
             <script type="text/javascript" src="/website_rentals/static/src/components/DateRangePicker.js"></script>
             <script type="text/javascript" src="/website_rentals/static/src/components/RentalWizard.js"></script>
+            <script type="text/javascript" src="/website_rentals/static/src/js/hooks/useCurrentTime.js"></script>
             <script type="text/javascript" src="/website_rentals/static/src/js/website_sale.js"></script>
         </xpath>
     </template>


### PR DESCRIPTION
https://github.com/Yenthe666/rental/issues/2

There's two things happening here:

**1. Buffer start times with security time.**
Any rental product that has security time (`preparation_time`), the start time of the rental process with be restricted. For example, if a product has a security time of 48 hours, it will now ever be possible to rent the product between now and 48 hours from now.

To do this, I implemented two validations:
    - Frontend validation. Get the current time (updated every second) and adds the security time to it. The `<input/>` uses a `min` attribute.
    - Backend validation. The scheduling helper adds a check in `can_rent` to make sure the product isn't being rented in a range that's not allows.

**2. Pulled out a datetime helper.**
I'm going to add a separate issue for this. Right now things are getting confusing between we are passing around `str` time "dates" to certain places, and then actual `datetime` object around to other places. So already parsing from string in some places and not others.

I pulled out that code into a `parse_datetime` function for now. The functionality has not changed, but the other issue will handle making sure that we're handling the dates and timezones properly.