### PR TITLE
[ADD] useExternalXml to load separate component templates into the Odoo qweb engine.

### DIFF
--- a/website_rentals/__manifest__.py
+++ b/website_rentals/__manifest__.py
@@ -17,7 +17,9 @@
     ],
     "images": [],
     "demo": [],
-    "qweb": [],
+    "qweb": [
+        "static/src/components/*.xml",
+    ],
     "data": [
         "views/assets.xml",
         "views/product_templates.xml",

--- a/website_rentals/static/src/components/DateRangePicker.js
+++ b/website_rentals/static/src/components/DateRangePicker.js
@@ -1,42 +1,8 @@
 odoo.define("website_rentals.DateRangePicker", function (require) {
     const { Component } = owl;
     const { useState } = owl.hooks;
-    const { xml, css } = owl.tags;
-
-    const TEMPLATE = xml `
-        <div id="timeslots" class="row flex">
-            <div id="timeslot_start">
-                <t t-slot="start-label"/>
-
-                <div class="row flex card-container">
-                    <div
-                        t-att-class="'card ' + (state.selectedTimeslots.start === timeslot.id ? 'selected ' : '')  + (timeslot.disabled ? 'disabled ' : '')"
-                        t-on-click="selectStartTimeslot(timeslot)"
-                        t-foreach="filterStartTimeslots(state.timeslotsStart)"
-                        t-as="timeslot"
-                    >
-                        <p t-esc="timeslot.title"/>
-                        <p><small t-if="timeslot.subtitle" t-esc="timeslot.subtitle"/></p>
-                    </div>
-                </div>
-            </div>
-            <div id="timeslot_end">
-                <t t-slot="end-label"/>
-
-                <div class="row flex card-container">
-                    <div
-                        t-att-class="'card ' + (state.selectedTimeslots.end === timeslot.id ? 'selected ' : '') + (timeslot.disabled ? 'disabled ' : '')"
-                        t-on-click="selectEndTimeslot(timeslot)"
-                        t-foreach="filterEndTimeslots(state.timeslotsEnd)"
-                        t-as="timeslot"
-                    >
-                        <p t-esc="timeslot.title"/>
-                        <p><small t-if="timeslot.subtitle" t-esc="timeslot.subtitle"/></p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    `;
+    const { css } = owl.tags;
+    const useExternalXml = require("website_rentals.useExternalXml");
 
     const STYLE = css `
         #timeslots #timeslot_start,
@@ -93,7 +59,7 @@ odoo.define("website_rentals.DateRangePicker", function (require) {
     `;
 
     class DateRangePicker extends Component {
-        static template = TEMPLATE;
+        static template = "website_rentals.DateRangePicker";
         static style = STYLE;
 
         state = useState({
@@ -105,6 +71,10 @@ odoo.define("website_rentals.DateRangePicker", function (require) {
                 end: undefined,
             }
         })
+
+        setup() {
+            useExternalXml(["/website_rentals/static/src/components/DateRangePicker.xml"]);
+        }
 
         selectStartTimeslot(timeslot) {
             this.state.selectedTimeslots.start = timeslot.id;

--- a/website_rentals/static/src/components/DateRangePicker.xml
+++ b/website_rentals/static/src/components/DateRangePicker.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="website_rentals.DateRangePicker" owl="1">
+        <div id="timeslots" class="row flex">
+            <div id="timeslot_start">
+                <t t-slot="start-label"/>
+
+                <div class="row flex card-container">
+                    <div
+                        t-att-class="'card ' + (state.selectedTimeslots.start === timeslot.id ? 'selected ' : '')  + (timeslot.disabled ? 'disabled ' : '')"
+                        t-on-click="selectStartTimeslot(timeslot)"
+                        t-foreach="filterStartTimeslots(state.timeslotsStart)"
+                        t-as="timeslot"
+                    >
+                        <p t-esc="timeslot.title"/>
+                        <p><small t-if="timeslot.subtitle" t-esc="timeslot.subtitle"/></p>
+                    </div>
+                </div>
+            </div>
+            <div id="timeslot_end">
+                <t t-slot="end-label"/>
+
+                <div class="row flex card-container">
+                    <div
+                        t-att-class="'card ' + (state.selectedTimeslots.end === timeslot.id ? 'selected ' : '') + (timeslot.disabled ? 'disabled ' : '')"
+                        t-on-click="selectEndTimeslot(timeslot)"
+                        t-foreach="filterEndTimeslots(state.timeslotsEnd)"
+                        t-as="timeslot"
+                    >
+                        <p t-esc="timeslot.title"/>
+                        <p><small t-if="timeslot.subtitle" t-esc="timeslot.subtitle"/></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/website_rentals/static/src/components/RentalWizard.js
+++ b/website_rentals/static/src/components/RentalWizard.js
@@ -1,128 +1,10 @@
 odoo.define("website_rentals.RentalWizard", function (require) {
     const { Component } = owl;
-    const { useState, useRef, useEffect } = owl.hooks;
-    const { xml, css } = owl.tags;
+    const { useState, useRef } = owl.hooks;
+    const { css } = owl.tags;
     const DateRangePicker = require("website_rentals.DateRangePicker");
+    const useExternalXml = require("website_rentals.useExternalXml");
     const wUtils = require("website.utils");
-
-    const TEMPLATE = xml `
-        <div id="rental_wizard" class="modal">
-            <div class="modal-dialog modal-dialog-scrollable d-flex s_popup_size_full">
-                <div class="modal-content oe_structure">
-                    <div class="modal-body">
-                        <button
-                            type="button"
-                            class="close"
-                            data-dismiss="modal"
-                            t-on-click="cancel"
-                            style="position:absolute; right:12px; top:10px; z-index:9999;">
-                            <span
-                                role="img"
-                                aria-label="Close">×</span>
-                            <span class="sr-only">Close</span>
-                        </button>
-
-                        <section class="o_colored_level o_cc o_cc1">
-                            <form t-on-submit.prevent="submit" t-if="state.product">
-                                <div class="container">
-                                    <div class="row">
-                                        <h2 t-if="state.product.display_name" t-esc="state.product.display_name" class="w-full" style="display:block; padding:0 0 6px 0; margin:0;"/>
-                                        <p t-if="state.product.description_sale" t-esc="state.product.description_sale" class="w-full" style="display:block;"/>
-                                    </div>
-                                    <div class="row" style="margin-top:12px;">
-                                        <p class="w-full"><strong>Dates</strong></p>
-                                        <div class="flex" style="align-items:center;">
-                                            <input
-                                                t-model="state.startDateInput"
-                                                t-on-change="onDateChange"
-                                                class="form-control"
-                                                name="pickup_date"
-                                                type="date"
-                                                autocomplete="off"
-                                                required="1"
-                                                t-att-min="today()"
-                                                t-att-disabled="state.loading"/>
-                                            <span style="padding:0 8px;">to</span>
-                                            <input
-                                                t-model="state.endDateInput"
-                                                t-on-change="onDateChange"
-                                                class="form-control"
-                                                name="return_date"
-                                                type="date"
-                                                autocomplete="off"
-                                                required="1"
-                                                t-att-min="state.startDateInput || today()"
-                                                t-att-disabled="!state.startDateInput || state.loading"/>
-                                        </div>
-                                    </div>
-
-                                    <!-- NOTE: Cannot use t-if here because it causes issues when trying to reference
-                                        subcomponents defined in this block. -->
-                                    <div t-att-class="(state.startDateInput &amp;&amp; state.endDateInput &amp;&amp; !state.loading) ? '' : 'd-none'">
-                                        <div t-if="!state.quantityAvailable" class="row">
-                                            <p class="text-danger">No quantity available.</p>
-                                        </div>
-                                        <t t-if="state.quantityAvailable">
-                                            <div id="product_qty" class="row flex">
-                                                <p class="w-full" style="margin-top:20px;"><strong>Quantity</strong></p>
-                                                <input
-                                                    t-model="state.quantity"
-                                                    t-on-change="onQtyChange"
-                                                    type="number"
-                                                    class="form-control quantity"
-                                                    name="quantity"
-                                                    min="1"
-                                                    t-att-max="state.quantityAvailable"
-                                                    autocomplete="off"
-                                                    required="1"/>
-                                                <p class="w-full" style="margin-top:20px;">
-                                                    (<span t-esc="state.quantityAvailable"/> Units Available)
-                                                </p>
-                                            </div>
-                                            <DateRangePicker t-ref="pickup-return-picker" onSelect="onTimeslotSelect.bind(state.this)">
-                                                <t t-set-slot="start-label">
-                                                    <h3><strong>Start</strong></h3>
-                                                    <p t-esc="startDate().format('DD.MM.YYYY')"/>
-                                                </t>
-                                                <t t-set-slot="end-label">
-                                                    <h3><strong>End</strong></h3>
-                                                    <p t-esc="endDate().format('DD.MM.YYYY')"/>
-                                                </t>
-                                            </DateRangePicker>
-                                        </t>
-                                    </div>
-                                </div>
-
-                                <hr/>
-
-                                <div class="row" t-if="state.price">
-                                    <p class="w-full"><strong>Price</strong></p>
-                                    <p class="w-full" t-esc="state.price"/>
-                                </div>
-                                <div class="row">
-                                    <p t-if="state.submitError" t-esc="state.submitError" class="text-danger"/>
-                                </div>
-                                <div class="row">
-                                    <button
-                                        class="btn btn-primary"
-                                        type="submit"
-                                        t-att-disabled="state.submitting || !state.quantityAvailable">
-                                        Add <i t-att-class="'fa fa-spinner fa-spin ' + (state.submitting ? '' : 'display-none')"/>
-                                    </button>
-                                    <button
-                                        t-on-click="cancel"
-                                        class="btn btn-link"
-                                        type="button">Cancel</button>
-                                </div>
-                            </form>
-                            <div t-else="">
-                                <i class="fa fa-spinner fa-spin" style="font-size: 24px"/>
-                            </div>
-                        </section>
-                    </div>
-                </div>
-            </div>
-        </div>`;
 
     const STYLE = css `
         #rental_wizard {
@@ -163,7 +45,7 @@ odoo.define("website_rentals.RentalWizard", function (require) {
     `;
 
     class RentalWizard extends Component {
-        static template = TEMPLATE;
+        static template = "website_rentals.RentalWizard";
         static style = STYLE;
         static components = { DateRangePicker };
 
@@ -188,6 +70,10 @@ odoo.define("website_rentals.RentalWizard", function (require) {
             super(parent, props)
             this.state.this = this;
             this.fetchProduct(props.productId);
+        }
+
+        setup() {
+            useExternalXml(["/website_rentals/static/src/components/RentalWizard.xml"]);
         }
 
         /**

--- a/website_rentals/static/src/components/RentalWizard.xml
+++ b/website_rentals/static/src/components/RentalWizard.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="website_rentals.RentalWizard" owl="1">
+        <div id="rental_wizard" class="modal">
+            <div class="modal-dialog modal-dialog-scrollable d-flex s_popup_size_full">
+                <div class="modal-content oe_structure">
+                    <div class="modal-body">
+                        <button
+                            type="button"
+                            class="close"
+                            data-dismiss="modal"
+                            t-on-click="cancel"
+                            style="position:absolute; right:12px; top:10px; z-index:9999;">
+                            <span
+                                role="img"
+                                aria-label="Close">×</span>
+                            <span class="sr-only">Close</span>
+                        </button>
+
+                        <section class="o_colored_level o_cc o_cc1">
+                            <form t-on-submit.prevent="submit" t-if="state.product">
+                                <div class="container">
+                                    <div class="row">
+                                        <h2 t-if="state.product.display_name" t-esc="state.product.display_name" class="w-full" style="display:block; padding:0 0 6px 0; margin:0;"/>
+                                        <p t-if="state.product.description_sale" t-esc="state.product.description_sale" class="w-full" style="display:block;"/>
+                                    </div>
+                                    <div class="row" style="margin-top:12px;">
+                                        <p class="w-full"><strong>Dates</strong></p>
+                                        <div class="flex" style="align-items:center;">
+                                            <input
+                                                t-model="state.startDateInput"
+                                                t-on-change="onDateChange"
+                                                class="form-control"
+                                                name="pickup_date"
+                                                type="date"
+                                                autocomplete="off"
+                                                required="1"
+                                                t-att-min="today()"
+                                                t-att-disabled="state.loading"/>
+                                            <span style="padding:0 8px;">to</span>
+                                            <input
+                                                t-model="state.endDateInput"
+                                                t-on-change="onDateChange"
+                                                class="form-control"
+                                                name="return_date"
+                                                type="date"
+                                                autocomplete="off"
+                                                required="1"
+                                                t-att-min="state.startDateInput || today()"
+                                                t-att-disabled="!state.startDateInput || state.loading"/>
+                                        </div>
+                                    </div>
+
+                                    <!-- NOTE: Cannot use t-if here because it causes issues when trying to reference
+                                        subcomponents defined in this block. -->
+                                    <div t-att-class="(state.startDateInput &amp;&amp; state.endDateInput &amp;&amp; !state.loading) ? '' : 'd-none'">
+                                        <div t-if="!state.quantityAvailable" class="row">
+                                            <p class="text-danger">No quantity available.</p>
+                                        </div>
+                                        <t t-if="state.quantityAvailable">
+                                            <div id="product_qty" class="row flex">
+                                                <p class="w-full" style="margin-top:20px;"><strong>Quantity</strong></p>
+                                                <input
+                                                    t-model="state.quantity"
+                                                    t-on-change="onQtyChange"
+                                                    type="number"
+                                                    class="form-control quantity"
+                                                    name="quantity"
+                                                    min="1"
+                                                    t-att-max="state.quantityAvailable"
+                                                    autocomplete="off"
+                                                    required="1"/>
+                                                <p class="w-full" style="margin-top:20px;">
+                                                    (<span t-esc="state.quantityAvailable"/> Units Available)
+                                                </p>
+                                            </div>
+                                            <DateRangePicker t-ref="pickup-return-picker" onSelect="onTimeslotSelect.bind(state.this)">
+                                                <t t-set-slot="start-label">
+                                                    <h3><strong>Start</strong></h3>
+                                                    <p t-esc="startDate().format('DD.MM.YYYY')"/>
+                                                </t>
+                                                <t t-set-slot="end-label">
+                                                    <h3><strong>End</strong></h3>
+                                                    <p t-esc="endDate().format('DD.MM.YYYY')"/>
+                                                </t>
+                                            </DateRangePicker>
+                                        </t>
+                                    </div>
+                                </div>
+
+                                <hr/>
+
+                                <div class="row" t-if="state.price">
+                                    <p class="w-full"><strong>Price</strong></p>
+                                    <p class="w-full" t-esc="state.price"/>
+                                </div>
+                                <div class="row">
+                                    <p t-if="state.submitError" t-esc="state.submitError" class="text-danger"/>
+                                </div>
+                                <div class="row">
+                                    <button
+                                        class="btn btn-primary"
+                                        type="submit"
+                                        t-att-disabled="state.submitting || !state.quantityAvailable">
+                                        Add <i t-att-class="'fa fa-spinner fa-spin ' + (state.submitting ? '' : 'display-none')"/>
+                                    </button>
+                                    <button
+                                        t-on-click="cancel"
+                                        class="btn btn-link"
+                                        type="button">Cancel</button>
+                                </div>
+                            </form>
+                            <div t-else="">
+                                <i class="fa fa-spinner fa-spin" style="font-size: 24px"/>
+                            </div>
+                        </section>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/website_rentals/static/src/js/useExternalXml.js
+++ b/website_rentals/static/src/js/useExternalXml.js
@@ -1,0 +1,35 @@
+odoo.define("website_rentals.useExternalXml", function(require) {
+    const { useEnv, onWillStart } = owl.hooks;
+
+    /**
+     * At this point, there is no support in Odoo for loading Owl XML templates
+     * into the Odoo QWeb engine. This mean that Owl will not be able to
+     * recongize templates by their t-name.
+     *
+     * This hook can be used to manually load templates in as a workaround.
+     *
+     * This was a recommended from the Odoo core team:
+     * https://github.com/odoo/odoo/issues/75426#issuecomment-903897145
+     *
+     * Usage:
+     *
+     *     const { Component } = owl;
+     *     const useExternalXml = require("website_rentals.useExternalXml");
+     *
+     *     class MyComponent extends Component {
+     *         static template = "my_module.MyComponent";
+     *
+     *         setup() {
+     *             useExternalXml(["/my_module/static/src/components/MyComponent.xml"]);
+     *         }
+     *     }
+     */
+    return function useExternalXml(urls) {
+        const env = useEnv();
+        onWillStart(async() => {
+            const requests = await Promise.all(urls.map(url => fetch(url)));
+            const contents = await Promise.all(requests.map(req => req.text()));
+            contents.forEach(xml => env.qweb.addTemplates(xml));
+        });
+    };
+});

--- a/website_rentals/views/assets.xml
+++ b/website_rentals/views/assets.xml
@@ -4,6 +4,7 @@
         <xpath expr="script[last()]" position="after">
             <script type="text/javascript" src="/website_rentals/static/src/components/DateRangePicker.js"></script>
             <script type="text/javascript" src="/website_rentals/static/src/components/RentalWizard.js"></script>
+            <script type="text/javascript" src="/website_rentals/static/src/js/useExternalXml.js"></script>
             <script type="text/javascript" src="/website_rentals/static/src/js/website_sale.js"></script>
         </xpath>
     </template>


### PR DESCRIPTION
https://github.com/Yenthe666/rental/issues/3

Third time is the charm :crossed_fingers: 

Following the recommendations from the Odoo core team here https://github.com/odoo/odoo/issues/75426#issuecomment-903897145

I've separated the component xml into qweb templates again. Then I'm using a custom hook to load those templates in on `setup` of each component. The components work as expected and can reference the xml ids properly.

---

In terms of translations, I went through the following steps:
- Exported an `fr` po file, which did include the missing terms from before. For example "No quantity available."
- I added translations, and tested the po file by adding it to the module.

At this point, it was translating as expected as far as I could tell. 