### PR TITLE
[BUG] prevent templates from erroring when trying to re-register via qweb

### DIFF
--- a/website_rentals/static/src/components/RentalWizard.js
+++ b/website_rentals/static/src/components/RentalWizard.js
@@ -66,7 +66,7 @@ odoo.define("website_rentals.RentalWizard", function (require) {
         refs = {
             pickupReturnPicker: useRef("pickup-return-picker")
         };
-        
+
         time = useCurrentTime();
 
         constructor(parent, props) {

--- a/website_rentals/views/assets.xml
+++ b/website_rentals/views/assets.xml
@@ -4,8 +4,8 @@
         <xpath expr="script[last()]" position="after">
             <script type="text/javascript" src="/website_rentals/static/src/components/DateRangePicker.js"></script>
             <script type="text/javascript" src="/website_rentals/static/src/components/RentalWizard.js"></script>
-            <script type="text/javascript" src="/website_rentals/static/src/js/useExternalXml.js"></script>
             <script type="text/javascript" src="/website_rentals/static/src/js/hooks/useCurrentTime.js"></script>
+            <script type="text/javascript" src="/website_rentals/static/src/js/hooks/useExternalXml.js"></script>
             <script type="text/javascript" src="/website_rentals/static/src/js/website_sale.js"></script>
         </xpath>
     </template>


### PR DESCRIPTION
Issue https://github.com/Yenthe666/rental/issues/12

**Previous Behavior:**
When clicking Check Availability on a product page, closing the pop up, and then clicking Check Availability again, an exception was thrown. The exception came from the `addTemplates` function in qweb because the template was being registered multiple times.

**Expected Behavior**
No error. Pop up appears again.

---

I updated the `useExternalXml` hook so that it ignores those exceptions. There was not a reasonable way to hook into the qweb templates and check if they had already been registered. We would've had to actually parse the xml, iterate through it, and check.

The more elegant solution seemed to be to just suppress the exception. I separate that out into a `utils` js module and then wrote `QUnit` tests for it as well.