### PR TITLE
[ADD] take security time into account for timeslots

### DIFF
--- a/website_rentals/models/product.py
+++ b/website_rentals/models/product.py
@@ -49,6 +49,7 @@ class Product(models.Model):
         # Break up the day into segements of `interval size`. If the smallest
         # pricing rule is 2 hours, then this will divy up the day into the slots
         # 2:00, 4:00, 6:00.
+
         timeslots = []
         current_timeslot = datetime.datetime(
             year=date.year,
@@ -71,11 +72,15 @@ class Product(models.Model):
                 minute=price_rule.end_time_minutes
             )
 
+        # Account for security time padding.
+        if self.preparation_time:
+            current_timeslot += datetime.timedelta(hours=self.preparation_time)
+
         while True:
+            if current_timeslot > date:
+                break
             if current_timeslot > now:
                 timeslots.append(current_timeslot.strftime("%H:%M"))
             current_timeslot += datetime.timedelta(hours=price_rule.duration)
-            if current_timeslot > date:
-                break
 
         return timeslots

--- a/website_rentals/static/src/components/DateRangePicker.xml
+++ b/website_rentals/static/src/components/DateRangePicker.xml
@@ -6,14 +6,19 @@
                 <t t-slot="start-label"/>
 
                 <div class="row flex card-container">
-                    <div
-                        t-att-class="'card ' + (state.selectedTimeslots.start === timeslot.id ? 'selected ' : '')  + (timeslot.disabled ? 'disabled ' : '')"
-                        t-on-click="selectStartTimeslot(timeslot)"
-                        t-foreach="filterStartTimeslots(state.timeslotsStart)"
-                        t-as="timeslot"
-                    >
-                        <p t-esc="timeslot.title"/>
-                        <p><small t-if="timeslot.subtitle" t-esc="timeslot.subtitle"/></p>
+                    <t t-if="filterStartTimeslots(state.timeslotsStart).length">
+                        <div
+                            t-att-class="'card ' + (state.selectedTimeslots.start === timeslot.id ? 'selected ' : '')  + (timeslot.disabled ? 'disabled ' : '')"
+                            t-on-click="selectStartTimeslot(timeslot)"
+                            t-foreach="filterStartTimeslots(state.timeslotsStart)"
+                            t-as="timeslot"
+                        >
+                            <p t-esc="timeslot.title"/>
+                            <p><small t-if="timeslot.subtitle" t-esc="timeslot.subtitle"/></p>
+                        </div>
+                    </t>
+                    <div t-else="">
+                        <p>No timeslots available on this day.</p>
                     </div>
                 </div>
             </div>
@@ -21,14 +26,19 @@
                 <t t-slot="end-label"/>
 
                 <div class="row flex card-container">
-                    <div
-                        t-att-class="'card ' + (state.selectedTimeslots.end === timeslot.id ? 'selected ' : '') + (timeslot.disabled ? 'disabled ' : '')"
-                        t-on-click="selectEndTimeslot(timeslot)"
-                        t-foreach="filterEndTimeslots(state.timeslotsEnd)"
-                        t-as="timeslot"
-                    >
-                        <p t-esc="timeslot.title"/>
-                        <p><small t-if="timeslot.subtitle" t-esc="timeslot.subtitle"/></p>
+                    <t t-if="filterEndTimeslots(state.timeslotsEnd).length">
+                        <div
+                            t-att-class="'card ' + (state.selectedTimeslots.end === timeslot.id ? 'selected ' : '') + (timeslot.disabled ? 'disabled ' : '')"
+                            t-on-click="selectEndTimeslot(timeslot)"
+                            t-foreach="filterEndTimeslots(state.timeslotsEnd)"
+                            t-as="timeslot"
+                        >
+                            <p t-esc="timeslot.title"/>
+                            <p><small t-if="timeslot.subtitle" t-esc="timeslot.subtitle"/></p>
+                        </div>
+                    </t>
+                    <div t-else="">
+                        <p>No timeslots available on this day.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Issue https://github.com/Yenthe666/rental/issues/2

Takes `preparation_time` (security time) into account when generating time slots. With this in place, there's a chance time slots end up empty, so I also added a short paragraph to the date picker widget in case they are empty. Vs just showing a blank section could confuse the customer.