### PR TITLE
Invalid timeslot generation

### DIFF
--- a/website_rentals/controllers/website_rental_controller.py
+++ b/website_rentals/controllers/website_rental_controller.py
@@ -54,11 +54,11 @@ class WebsiteRentalController(Controller):
         website=True,
         csrf=False
     )
-    def get_rental_hourly_timeslots(self, product_id, date):
+    def get_rental_hourly_timeslots(self, product_id, start_date, stop_date):
         return request.env["product.product"]\
             .sudo()\
             .browse(product_id)\
-            .get_rental_hourly_timeslots(date)
+            .get_rental_hourly_timeslots(start_date, stop_date)
 
     @route(
         ["/website/rentals/get_price"],

--- a/website_rentals/helpers/__init__.py
+++ b/website_rentals/helpers/__init__.py
@@ -1,2 +1,3 @@
+from . import misc
 from . import scheduling
 from . import time

--- a/website_rentals/helpers/misc.py
+++ b/website_rentals/helpers/misc.py
@@ -1,0 +1,7 @@
+def float_range(start, stop, step=1.0):
+    """Floating point implementation of range()"""
+    res = []
+    while start <= stop:
+        res.append(start)
+        start += step
+    return res

--- a/website_rentals/helpers/time.py
+++ b/website_rentals/helpers/time.py
@@ -1,6 +1,26 @@
 import dateutil
+import datetime
+
+
+def float_to_time(number):
+    """Convert a float to hours and minutes."""
+    return {
+        "hours": int(number),
+        "minutes": int((number - int(number)) * 60),
+    }
+
 
 def parse_datetime(data):
-    if type(data) != str:
+    """Parses either a string, date, or datetime into a datetime that is not timezone aware."""
+    if type(data) == str:
+        data = dateutil.parser.parse(data)
+
+    if type(data) == datetime.date:
+        return datetime.datetime(
+            year=data.year, month=data.month, day=data.day, hour=0, minute=0, second=0
+        )
+
+    if type(data) == datetime.datetime:
         return data.replace(tzinfo=None)
-    return dateutil.parser.parse(data).replace(tzinfo=None)
+
+    raise Exception("parse_datetime only accepts a datetime or date as a parameter.")

--- a/website_rentals/i18n/de.po
+++ b/website_rentals/i18n/de.po
@@ -92,7 +92,7 @@ msgstr "Zuletzt geändert am"
 #: model_terms:ir.ui.view,arch_db:website_rentals.cart_lines
 #: model_terms:ir.ui.view,arch_db:website_sale.cart_summary
 #, python-format
-msgid "No quantity available"
+msgid "No availability"
 msgstr "Keine Menge verfügbar"
 
 #. module: website_rentals

--- a/website_rentals/i18n/de_CH.po
+++ b/website_rentals/i18n/de_CH.po
@@ -108,7 +108,7 @@ msgstr "Zuletzt geändert am"
 #. openerp-web
 #: code:addons/website_rentals/static/src/components/RentalWizard.xml:0
 #, python-format
-msgid "No quantity available."
+msgid "No availability."
 msgstr "Keine Menge verfügbar."
 
 #. module: website_rentals

--- a/website_rentals/i18n/fr.po
+++ b/website_rentals/i18n/fr.po
@@ -108,7 +108,7 @@ msgstr "Dernière modification le"
 #. openerp-web
 #: code:addons/website_rentals/static/src/components/RentalWizard.xml:0
 #, python-format
-msgid "No quantity available."
+msgid "No availability."
 msgstr "Pas de quantité disponible"
 
 #. module: website_rentals

--- a/website_rentals/models/product.py
+++ b/website_rentals/models/product.py
@@ -17,27 +17,19 @@ class Product(models.Model):
             self, start_date, stop_date
         )
 
-    def get_rental_hourly_timeslots(self, date=None):
+    def get_rental_hourly_timeslots(self, start_date, stop_date=None):
+        return self.env["website.rentals.scheduling"].get_rental_hourly_timeslots(
+            self, start_date, stop_date
+        )
+
+    def shortest_price_rule(self):
         """
-        Generates a set of timeslots for a certain time period based on this
-        products rental pricing rules.
+        Returns the shortest duration pricing rule.
 
-        The smallest interval, hourly pricing rule is used. For example, if a
-        product has three rules for 1 hour, 2 hour, and 3 hours, then this is
-        going to generate hourly time slots.
+        This is used as an interval for generating pricing rules in the
+        scheduling helper.
         """
-
-        now = datetime.datetime.now()
-        date = parse_datetime(date)
-
-        if not self.rental_pricing_ids:
-            return
-
-        if "hour" not in self.mapped("rental_pricing_ids.unit"):
-            return
-
-        # Find the lowest duration "hour" pricing rule
-        price_rule = self.env["rental.pricing"].search(
+        return self.env["rental.pricing"].search(
             [
                 ("id", "in", self.rental_pricing_ids.ids),
                 ("unit", "=", "hour")
@@ -45,37 +37,3 @@ class Product(models.Model):
             order="duration asc",
             limit=1,
         )
-
-        # Break up the day into segements of `interval size`. If the smallest
-        # pricing rule is 2 hours, then this will divy up the day into the slots
-        # 2:00, 4:00, 6:00.
-        timeslots = []
-        current_timeslot = datetime.datetime(
-            year=date.year,
-            month=date.month,
-            day=date.day,
-            hour=0,
-            minute=0,
-            second=0
-        )
-
-        if price_rule.start_time:
-            current_timeslot = current_timeslot.replace(
-                hour=price_rule.start_time_hour,
-                minute=price_rule.start_time_minutes,
-            )
-
-        if price_rule.end_time:
-            date = date.replace(
-                hour=price_rule.end_time_hour,
-                minute=price_rule.end_time_minutes
-            )
-
-        while True:
-            if current_timeslot > now:
-                timeslots.append(current_timeslot.strftime("%H:%M"))
-            current_timeslot += datetime.timedelta(hours=price_rule.duration)
-            if current_timeslot > date:
-                break
-
-        return timeslots

--- a/website_rentals/static/src/components/DateRangePicker.js
+++ b/website_rentals/static/src/components/DateRangePicker.js
@@ -9,6 +9,7 @@ odoo.define("website_rentals.DateRangePicker", function (require) {
         #timeslots #timeslot_end {
             flex-grow: 1;
             margin-top: 8px;
+            min-width: 49%;
         }
 
         #timeslots {

--- a/website_rentals/static/src/components/RentalWizard.xml
+++ b/website_rentals/static/src/components/RentalWizard.xml
@@ -62,7 +62,7 @@
                                         subcomponents defined in this block. -->
                                     <div t-att-class="(state.startDateInput &amp;&amp; state.endDateInput &amp;&amp; !state.loading) ? '' : 'd-none'">
                                         <div t-if="!state.quantityAvailable" class="row">
-                                            <p class="text-danger pt-2">No quantity available.</p>
+                                            <p class="text-danger pt-2">No availability.</p>
                                         </div>
                                         <t t-if="state.quantityAvailable">
                                             <div id="product_qty" class="row flex">

--- a/website_rentals/tests/__init__.py
+++ b/website_rentals/tests/__init__.py
@@ -1,2 +1,4 @@
+from . import test_helpers
 from . import test_rental_pricing
 from . import test_scheduling
+from . import test_timeslot_generation

--- a/website_rentals/tests/test_helpers.py
+++ b/website_rentals/tests/test_helpers.py
@@ -1,0 +1,63 @@
+import datetime
+from odoo.tests import TransactionCase
+from odoo.addons.website_rentals import helpers
+
+
+class HelpersTests(TransactionCase):
+    def test_parse_date_string(self):
+        parsed = helpers.time.parse_datetime("2021-09-10")
+
+        assert type(parsed) == datetime.datetime
+        assert parsed.year == 2021
+        assert parsed.month == 9
+        assert parsed.day == 10
+        assert parsed.hour == 0
+        assert parsed.minute == 0
+        assert parsed.second == 0
+        assert parsed.tzinfo == None
+
+    def test_parse_datetime_string(self):
+        parsed = helpers.time.parse_datetime("2021-09-10 15:10:05")
+
+        assert type(parsed) == datetime.datetime
+        assert parsed.year == 2021
+        assert parsed.month == 9
+        assert parsed.day == 10
+        assert parsed.hour == 15
+        assert parsed.minute == 10
+        assert parsed.second == 5
+        assert parsed.tzinfo == None
+
+    def test_parse_date_object(self):
+        today = datetime.date.today()
+        parsed = helpers.time.parse_datetime(today)
+
+        assert type(parsed) == datetime.datetime
+        assert parsed.year == 2021
+        assert parsed.month == 9
+        assert parsed.day == 10
+        assert parsed.hour == 0
+        assert parsed.minute == 0
+        assert parsed.second == 0
+        assert parsed.tzinfo == None
+
+    def test_parse_datetime_object(self):
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        parsed = helpers.time.parse_datetime(now)
+
+        assert parsed.year == now.year
+        assert parsed.month == now.month
+        assert parsed.day == now.day
+        assert parsed.hour == now.hour
+        assert parsed.minute == now.minute
+        assert parsed.second == now.second
+        assert parsed.tzinfo == None
+
+    def test_nonesense_parameters_should_raise_exception(self):
+        with self.assertRaises(Exception):
+            helpers.time.parse_datetime(False)
+
+    def test_basic_float_range(self):
+        assert helpers.misc.float_range(6.5, 9.51) == [6.5, 7.5, 8.5, 9.5]
+        assert helpers.misc.float_range(5.25, 7.10, step=0.25) == [5.25, 5.50, 5.75, 6.0, 6.25, 6.50, 6.75, 7.0]
+        assert helpers.misc.float_range(5.6, 6.0, step=0.2) == [5.6, 5.8, 6.0]

--- a/website_rentals/tests/test_timeslot_generation.py
+++ b/website_rentals/tests/test_timeslot_generation.py
@@ -1,0 +1,237 @@
+import datetime
+from freezegun import freeze_time
+from unittest import mock
+from odoo.tests import TransactionCase
+
+
+class TimeslotGenerationTests(TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+        self.scheduling = self.env["website.rentals.scheduling"]
+
+        # product sample data
+        self.blank_product = self.env["product.product"].create(
+            {
+                "name": "No Rental Pricing",
+                "categ_id": self.env.ref("sale_renting.cat_renting").id,
+                "type": "product",
+                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "uom_po_id": self.env.ref("uom.product_uom_unit").id,
+                "rent_ok": True,
+                "preparation_time": 0.0,  # hours
+            }
+        )
+        self.days_only_product = self.env["product.product"].create(
+            {
+                "name": "Days Only Rental Pricing",
+                "categ_id": self.env.ref("sale_renting.cat_renting").id,
+                "type": "product",
+                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "uom_po_id": self.env.ref("uom.product_uom_unit").id,
+                "rent_ok": True,
+                "preparation_time": 0.0,  # hours
+                "rental_pricing_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "duration": 1,
+                            "unit": "day",
+                            "price": 20.0,
+                            "start_time": 8.0,
+                            "end_time": 18.0,
+                        },
+                    ),
+                ],
+            }
+        )
+        self.meeting_room = self.env["product.product"].create(
+            {
+                "name": "New Meeting Room",
+                "categ_id": self.env.ref("sale_renting.cat_renting").id,
+                "type": "product",
+                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "uom_po_id": self.env.ref("uom.product_uom_unit").id,
+                "rent_ok": True,
+                "preparation_time": 0.0,  # hours
+                "extra_hourly": 15.0,
+                "extra_daily": 40.0,
+                "rental_pricing_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "duration": 4,
+                            "unit": "hour",
+                            "price": 20.0,
+                            "start_time": 8.0,
+                            "end_time": 18.0,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "duration": 8,
+                            "unit": "hour",
+                            "price": 40.0,
+                            "start_time": 8.0,
+                            "end_time": 18.0,
+                        },
+                    ),
+                ],
+            }
+        )
+
+    def test_no_rental_pricing_should_return_none(self):
+        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        assert not self.blank_product.get_rental_hourly_timeslots(tomorrow)
+
+    def test_no_hourly_rental_pricing_should_return_none(self):
+        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        assert not self.days_only_product.get_rental_hourly_timeslots(tomorrow)
+
+    def test_same_day_start_slot_generation(self):
+        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        timeslots = self.meeting_room.get_rental_hourly_timeslots(tomorrow)
+
+        assert timeslots["start"] == ["08:00", "12:00", "16:00"]
+
+    def test_same_day_stop_slot_generation(self):
+        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        timeslots = self.meeting_room.get_rental_hourly_timeslots(tomorrow)
+
+        assert timeslots["stop"] == [
+            "12:00",
+            "13:00",
+            "14:00",
+            "15:00",
+            "16:00",
+            "17:00",
+            "18:00",
+        ]
+
+    def test_different_day_start_slot_generation(self):
+        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        day_after_tomorrow = tomorrow + datetime.timedelta(days=1)
+        timeslots = self.meeting_room.get_rental_hourly_timeslots(
+            tomorrow, day_after_tomorrow
+        )
+
+        assert timeslots["start"] == [
+            "08:00",
+            "09:00",
+            "10:00",
+            "11:00",
+            "12:00",
+            "13:00",
+            "14:00",
+            "15:00",
+            "16:00",
+            "17:00",
+            "18:00",
+        ]
+
+    def test_different_day_stop_slot_generation(self):
+        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        day_after_tomorrow = tomorrow + datetime.timedelta(days=1)
+        timeslots = self.meeting_room.get_rental_hourly_timeslots(
+            tomorrow, day_after_tomorrow
+        )
+
+        assert timeslots["stop"] == [
+            "08:00",
+            "09:00",
+            "10:00",
+            "11:00",
+            "12:00",
+            "13:00",
+            "14:00",
+            "15:00",
+            "16:00",
+            "17:00",
+            "18:00",
+        ]
+
+    @freeze_time("2021-09-10 06:30:00")
+    def test_same_day_preparation_time_offset(self):
+        self.meeting_room.preparation_time = 3
+        timeslots = self.meeting_room.get_rental_hourly_timeslots(
+            datetime.datetime.now()
+        )
+        assert timeslots["start"] == ["12:00", "16:00"]
+        assert timeslots["stop"] == ["16:00", "17:00", "18:00"]
+
+    @freeze_time("2021-09-10 06:30:00")
+    def test_different_day_preparation_time_offset(self):
+        self.meeting_room.preparation_time = 3
+
+        today = datetime.datetime.now()
+        tomorrow = today + datetime.timedelta(days=1)
+        timeslots = self.meeting_room.get_rental_hourly_timeslots(today, tomorrow)
+
+        assert timeslots["start"] == [
+            "10:00",
+            "11:00",
+            "12:00",
+            "13:00",
+            "14:00",
+            "15:00",
+            "16:00",
+            "17:00",
+            "18:00",
+        ]
+        assert timeslots["stop"] == [
+            "08:00",
+            "09:00",
+            "10:00",
+            "11:00",
+            "12:00",
+            "13:00",
+            "14:00",
+            "15:00",
+            "16:00",
+            "17:00",
+            "18:00",
+        ]
+
+        day_after_tomorrow = tomorrow + datetime.timedelta(days=1)
+        timeslots = self.meeting_room.get_rental_hourly_timeslots(
+            tomorrow, day_after_tomorrow
+        )
+
+        assert timeslots["start"] == [
+            "08:00",
+            "09:00",
+            "10:00",
+            "11:00",
+            "12:00",
+            "13:00",
+            "14:00",
+            "15:00",
+            "16:00",
+            "17:00",
+            "18:00",
+        ]
+        assert timeslots["stop"] == [
+            "08:00",
+            "09:00",
+            "10:00",
+            "11:00",
+            "12:00",
+            "13:00",
+            "14:00",
+            "15:00",
+            "16:00",
+            "17:00",
+            "18:00",
+        ]
+
+    @freeze_time("2021-09-10 11:30:00")
+    def test_timeslots_should_only_generate_after_current_time(self):
+        timeslots = self.meeting_room.get_rental_hourly_timeslots(
+            datetime.datetime.now()
+        )
+        assert timeslots["start"] == ["12:00", "16:00"]
+        assert timeslots["stop"] == ["16:00", "17:00", "18:00"]


### PR DESCRIPTION
Issue https://github.com/Yenthe666/rental/issues/6

**Previous behavior:**
Previously, the timeslots were generated based on the shortest duration hourly pricing rule. This was used for both start and end time slots. For example, a produce with a 4 hour pricing rule from 8:00-18:00 would generate 8,12,16 for the start, but then 12, 16 for the end, where the end should actually be 12,13,14,...,18.

**New behavior:**
I refactored the timeslot generation, pulling it out of the product and into our scheduling logic. I found a few ways to simplify things by using a range function (had to implement a `float_range` since `range` only works on ints). I actually added in test scenarios.

Here's the two main test scenarios and expected outputs:

Given a product with the following rules:
```
4 Hour Duration from 08:00 - 18:00
8 Hour Duration from 08:00 - 18:00  
```

- Attempting to order from 9/10 - 9/10:
    - Start:
        - 08:00
        - 12:00
        - 16:00
    - Stop:
        - 12:00
        - 13:00
        - 14:00
        - 15:00
        - 16:00
        - 17:00
        - 18:00    

We didn't discuss different day ordering @Yenthe666 @TSOstefankeller . I didn't want to delay the issue futher, so went ahead and went with what I thought was common sense here. The step interval isn't used on the start day here, since the entire reservation is going to stretch over into the next day. So it's always going to greater than the 4 hours duration.

- Attempting to order from 9/10 - 9/11
    - Start:
        - 08:00
        - 09:00
        - 10:00
        - 11:00
        - 12:00
        - 13:00
        - 14:00
        - 15:00
        - 16:00
        - 17:00
        - 18:00
    - Stop:
        - 08:00
        - 09:00
        - 10:00
        - 11:00
        - 12:00
        - 13:00
        - 14:00
        - 15:00
        - 16:00
        - 17:00
        - 18:00
